### PR TITLE
feat: added docker-compose to create docker container with one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,7 @@ docker info
 Docker:
 
 ```bash
-docker run --name neo4j \
-  -p 7474:7474 \
-  -p 7687:7687 \
-  -e NEO4J_AUTH=neo4j/thisisthelocalpassword \
-  -d neo4j
-```
+docker compose run```
 
 ✅ Step 4: Verify That the Container Is Running Check if the Neo4j container is
 running:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  neo4j-apoc:
+    image: neo4j:latest
+    container_name: neo4j-apoc
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    environment:
+      NEO4J_apoc_export_file_enabled: "true"
+      NEO4J_apoc_import_file_enabled: "true"
+      NEO4J_apoc_import_file_use__neo4j__config: "true"
+      NEO4J_PLUGINS: '["apoc"]'
+      NEO4J_AUTH: "neo4j/thisisthelocalpassword"


### PR DESCRIPTION
Updated Readme with new instructions.
Instead of creating the docker container with the Neo4J instance, now the developer can simply run `docker compose up` and, in a similar way than Terraform, will create the container for development purposes